### PR TITLE
Prefer `extend-ignore` in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Configuration example (`setup.cfg`):
 
 ```ini
 [flake8]
-ignore =
+extend-ignore =
     E501,
     W505
 max-line-length = 90


### PR DESCRIPTION
This option is better than just `ignore` because it'll augment the default ignores list rather than replacing it