### PR TITLE
Only add token start to line length if first line in token

### DIFF
--- a/flake8_length/_parser.py
+++ b/flake8_length/_parser.py
@@ -67,8 +67,12 @@ def get_lines_info(token: tokenize.TokenInfo) -> Iterator[LineInfo]:
     # analyze every line of comments and multiline strings
     lines = token.string.splitlines()
     for offset, line in enumerate(lines):
+        line_length = get_line_length(line)
+        if offset == 0:
+            line_length += token.start[1]
         yield LineInfo(
             row=token.start[0] + offset,
-            length=token.start[1] + get_line_length(line),
+            length=line_length,
             line=line,
         )
+

--- a/flake8_length/_parser.py
+++ b/flake8_length/_parser.py
@@ -75,4 +75,3 @@ def get_lines_info(token: tokenize.TokenInfo) -> Iterator[LineInfo]:
             length=line_length,
             line=line,
         )
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,12 +3,13 @@ import tokenize
 
 # external
 import pytest
+from typing import Union
 
 # project
 from flake8_length._parser import TRUNCATE_TO, get_lines_info
 
 
-def to_tokens(lines: list):
+def to_tokens(lines: list[str]):
     readline = (line.encode() for line in lines).__next__
     return list(tokenize.tokenize(readline))
 
@@ -37,9 +38,19 @@ def to_tokens(lines: list):
         "'''\n  https://github.com/life4/deal\n'''",
         [3, TRUNCATE_TO + 2, 3],
     ),
+    (
+        ("print('''\n", ' 1' * 39 + '\n', "''')\n"),
+        # 5, 6, 9 = three tokens in print('''
+        # 78 = length of ' 1'*39
+        # 3, 4 = two tokens in ''')
+        [5, 6, 9, 78, 3, 4]
+    ),
 ])
-def test_get_lines_info(given: str, expected: int):
-    tokens = to_tokens([given])
+def test_get_lines_info(given: Union[str, list[str]], expected: int):
+    if isinstance(given, str):
+        given = [given]
+
+    tokens = to_tokens(given)
     print(*tokens, sep='\n')
     infos: list = []
     for token in tokens:


### PR DESCRIPTION
Fixes incorrect error reporting for the following python code:

```python
print("""
    This line is exactly 78 characters long but the linter reports it as 84...
""")
```

```
$ flake8 example.py
example.py:2:80: LN001 line is too long (84 > 79)
```

Hopefully this is correct, I'm not sure if there are tokens where the original behavior would be correct.