### PR TITLE
Ignore symbols at the end of the line

### DIFF
--- a/flake8_length/_parser.py
+++ b/flake8_length/_parser.py
@@ -20,8 +20,11 @@ EXCLUDED_TOKENS = frozenset({
 EXCLUDED_PAIRS = frozenset({
     (tokenize.OP, '('),
     (tokenize.OP, ')'),
+    (tokenize.OP, '['),
+    (tokenize.OP, ']'),
     (tokenize.OP, ','),
     (tokenize.OP, ';'),
+    (tokenize.OP, ':'),
 })
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,6 +30,15 @@ def to_tokens(lines: List[str]):
     ('"SELECT * FROM table"', [21]),
     ('"SELECT * FROM table_with_very_long_name"', [TRUNCATE_TO + 15]),
 
+    # ignored endline markers
+    ('123', [3]),
+    ('123,', [3]),
+    ('[123]', [4]),
+    ('(123)', [4]),
+    ('(123,)', [4]),
+    ('(123,);', [4]),
+    ('if 0:0', [2, 4, 6]),
+
     # multiline strings
     (
         "'''\n  hello world\n'''",


### PR DESCRIPTION
Ignore a few more tokens: `[ ] :`. If you ever got annoyed by a single symbol not fitting in the line limit, I got you covered ;)