### PR TITLE
Get value from Enum instead of the name of the Enum

### DIFF
--- a/flake8_length/_checker.py
+++ b/flake8_length/_checker.py
@@ -7,7 +7,7 @@ from ._parser import get_lines_info, Message
 
 
 Tokens = Sequence[tokenize.TokenInfo]
-TEMPLATE = '{v.code} {v.message} ({v.length} > {v.limit})'
+TEMPLATE = '{v.code} {v.message.value} ({v.length} > {v.limit})'
 
 
 class Violation(NamedTuple):


### PR DESCRIPTION
The message should be taking the `.value` from the Enum and not the Enum itself as that just returns the name of the Enum.

Like this:

```
.py:12:121: LN002 Message.LN002 (126 > 120)
```

Alternatively use https://pypi.org/project/StrEnum/ which is also included in the standard lib from 3.11 onwards.